### PR TITLE
aa.formExternalConfiguration extension

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
 			options:{
 				dest:'docs',
 				html5Mode:true,
-				scripts: [ 'docs/js/angular.min.js','src/aa.formExtensions.js','src/aa.notify.js','src/aa.select2.js'],
+				scripts: [ 'docs/js/angular.min.js','src/aa.formExtensions.js','src/aa.notify.js','src/aa.select2.js','src/aa.formExternalConfiguration.js'],
 				title: 'Angular Agility - Form Extensions',
 				startPage: '/api/aa.formExtensions'
 			},

--- a/src/aa.formExtensions.js
+++ b/src/aa.formExtensions.js
@@ -737,7 +737,6 @@
                 require: 'ngModel',
                 scope: false,
                 compile: function(element) {
-
                     var container = aaFormExtensions.validIconStrategy.getContainer(element);
 
                     var validIcon = angular.element(aaFormExtensions.validIconStrategy.validIcon);
@@ -911,7 +910,7 @@
                 validIcon: '<i class="fa fa-check fa-lg"></i>',
                 invalidIcon: '<i class="fa fa-exclamation-circle fa-lg"></i>',
                 getContainer: function(element) {
-                    var ele = angular.element('<div class="col-xs-1 validation-icons"></span>');
+                    var ele = angular.element('<div class="col-xs-1 validation-icons"></div>');
                     element.parent().after(ele);
                     return ele;
                 }

--- a/src/aa.formExternalConfiguration.js
+++ b/src/aa.formExternalConfiguration.js
@@ -1,0 +1,251 @@
+/*
+ * AngularAgility Form External Validation Configuration
+ *
+ * https://github.com/AngularAgility/AngularAgility
+ *
+ * Copyright (c) 2014 - Roland Zwaga
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ */
+
+/**
+ * @ngdoc overview
+ * @name aa.formExternalConfiguration
+ *
+ * @description
+ * This module contains the form extension directives that are used to easily generate
+ * angular form elements using an external configuration.
+ *
+ * Instead of defining all the validation specs directly in the markup, these specs
+ * can be passed to the aaConfiguredForm directive as a regular JavaScript object.
+ *
+ * This approach allows you to have the validation data to be retrieved from a server,
+ * for example.
+ * Also, when different kinds of form layouts/visualisations exist for the same data
+ * across an application, this approach might save a bunch of markup typing.
+ *
+ * The configuration object has an interface like this:
+ * var formconfig = {
+ *   validations:Object,
+ *   globals?:Object,
+ *   resolve?:Object,
+ *   resolveFn?:Function
+ * }
+ *
+ * A simple configuration looks like this:
+ *
+ <pre>
+     <script>
+         var app = angular.module('app', ['aa.formExternalConfiguration', 'aa.notify'])
+         .controller('main', ['$scope', function(scope) {
+            scope.user = {
+                name:'Test1',
+            };
+            scope.config = {
+                validations: {
+                    user:{
+                        name: {
+                            'ng-minlength':8,
+                            required:true
+                        },
+                    }
+                }
+            };
+        }]);
+     </script>
+     <div ng-controller="main">
+         <aa-configured-form validation-config="config" form-name="'exampleForm'">
+             <input type="text" ng-model="user.name" />
+         </aa-configured-form>
+     </div>
+ </pre>
+ *
+ * If there are validation specs you need to add to all applicable inputs, add a globals
+ * property:
+ *
+ <pre>
+     <script>
+     var app = angular.module('app', ['aa.formExternalConfiguration', 'aa.notify'])
+     .controller('main', ['$scope', function(scope) {
+                scope.user = {
+                    name:'Test1',
+                };
+                scope.config = {
+                    globals: {
+                        'aa-valid-icon':''
+                    },
+                    validations: {
+                        user:{
+                            name: {
+                                'ng-minlength':8,
+                                required:true
+                            },
+                        }
+                    }
+                };
+            }]);
+     </script>
+     <div ng-controller="main">
+         <aa-configured-form validation-config="config" form-name="'exampleForm'">
+             <input type="text" ng-model="user.name" />
+         </aa-configured-form>
+     </div>
+ </pre>
+ *
+ * If the scope name doesn't match the validation name for some reason,
+ * add a resolve property to the config like this:
+ *
+ <pre>
+     <script>
+     var app = angular.module('app', ['aa.formExternalConfiguration', 'aa.notify'])
+     .controller('main', ['$scope', function(scope) {
+                    scope.user = {
+                        name:'Test1',
+                    };
+                    scope.config = {
+                        resolve: {
+                            user:'UserType'
+                        },
+                        validations: {
+                            'UserType':{
+                                name: {
+                                    'ng-minlength':8,
+                                    required:true
+                                },
+                            }
+                        }
+                    };
+                }]);
+     </script>
+     <div ng-controller="main">
+         <aa-configured-form validation-config="config" form-name="'exampleForm'">
+             <input type="text" ng-model="user.name" />
+         </aa-configured-form>
+     </div>
+ </pre>
+ *
+ * If the resolving the scope name to the validation name is more complex,
+ * add a resolveFn property to the config:
+ *
+ <pre>
+     <script>
+     var app = angular.module('app', ['aa.formExternalConfiguration', 'aa.notify'])
+     .controller('main', ['$scope', function(scope) {
+                        scope.user = {
+                            name:'Test1',
+                            __type:'UserType'
+                        };
+                        scope.config = {
+                            resolveFn: function(modelValue){
+                                //modelValue === 'user.name'
+                                if (modelValue.indexOf('.') > -1) {
+                                    parts = modelValue.split('.');
+                                }
+                                var modelName = parts[parts.length-2];
+                                return scope[modelName]['__type'];
+                            },
+                            validations: {
+                                'UserType':{
+                                    name: {
+                                        'ng-minlength':8,
+                                        required:true
+                                    },
+                                }
+                            }
+                        };
+                    }]);
+     </script>
+     <div ng-controller="main">
+         <aa-configured-form validation-config="config" form-name="'exampleForm'">
+             <input type="text" ng-model="user.name" />
+         </aa-configured-form>
+     </div>
+ </pre>
+ *
+ * Known issue: Using aa-field or aa-field-group inside the aaConfiguredForm directive
+ * will result in errors like this:
+ * TypeError: Object #<Comment> has no method 'setAttribute'
+ *
+ */
+angular.module('aa.formExternalConfiguration', ['aa.formExtensions'])
+    .directive('aaConfiguredForm', ['$compile', function($compile) {
+        return {
+            restrict: 'EA',
+            replace:true,
+            template:'<div ng-transclude ng-form="{{formName}}"></div>',
+            transclude:true,
+            scope: {
+                validationConfig:'=',
+                formName:'='
+            },
+            compile: function(elem) {
+                var _this = this;
+                elem.removeAttr('ng-transclude');
+                return function (scope, elem, attr) {
+                    if (scope.validationConfig) {
+                        _this.findFormElements(['input', 'select'], elem, scope);
+                    }
+                    $compile(elem)(scope);
+                };
+            },
+            findFormElements: function(names, rootElement, scope) {
+                var _this = this;
+                angular.forEach(names, function(name) {
+                    _this.processElements(name, rootElement, scope);
+                });
+            },
+            processElements: function(name, rootElement, scope) {
+                var elements = rootElement.find(name);
+                for(var i= 0, ii = elements.length; i < ii; i++) {
+                    this.processElement(elements[i], scope);
+                }
+            },
+            processElement:function(element, scope) {
+                var jqElm = angular.element(element);
+                var nameAttr = jqElm.attr('ng-model') || jqElm.attr('ngModel');
+                if (nameAttr) {
+                    jqElm.attr('name', nameAttr.split('.').join('-'));
+                    this.addAttributes(scope, jqElm, nameAttr);
+                }
+            },
+            addAttributes: function(scope, jqElm, modelValue) {
+                var parts;
+                var name;
+                var config = scope.validationConfig;
+
+                if (modelValue.indexOf('.') > -1) {
+                    parts = modelValue.split('.');
+                } else {
+                    throw new Error("the name attribute value needs to contain a '.' char");
+                }
+
+                var modelName = parts[parts.length-2];
+                var propName = parts[parts.length-1];
+
+                modelName = this.resolveModelName(modelName, modelValue, config);
+
+                var validation = config.validations[modelName];
+                if (validation) {
+                    var validationAttrs = validation[propName];
+                    for (name in validationAttrs) {
+                        jqElm.attr(name, validationAttrs[name]);
+                    }
+
+                    var globals = config.globals;
+                    if (globals) {
+                        for (name in globals) {
+                            jqElm.attr(name, globals[name]);
+                        }
+                    }
+                }
+            },
+            resolveModelName: function(modelName, modelValue, config) {
+                if (!config.resolveFn) {
+                    return (config.resolve && config.resolve[modelName]) ? config.resolve[modelName] : modelName;
+                } else {
+                    return config.resolveFn(modelValue);
+                }
+            }
+        };
+    }]);

--- a/test/aa.formExternalConfigurationSpecs.js
+++ b/test/aa.formExternalConfigurationSpecs.js
@@ -1,0 +1,117 @@
+/**
+ * Created by Roland on 4/3/2014.
+ */
+describe('aa.formExternalConfiguration.js >', function () {
+    beforeEach(module('aa.formExternalConfiguration'));
+
+    describe('aaConfiguredForm >', function () {
+        var scope, compile;
+
+        beforeEach(inject(function($compile, $rootScope) {
+            scope = $rootScope.$new();
+            compile = $compile;
+        }));
+
+        it('copies the validation config to the input element', function () {
+            scope.config = {
+                validations: {
+                    user:{
+                        name: {
+                            'ng-minlength':5
+                        }
+                    }
+                }
+            };
+            scope.user = {
+                name:'test'
+            };
+
+            var directive = angular.element("<aa-configured-form validation-config=\"config\" form-name=\"'exampleForm'\"></aa-configured-form>");
+            var element = angular.element('<input type="test" ng-model="user.name"/>');
+            directive.append(element);
+
+            compile(directive)(scope);
+            element = directive.find('input');
+            expect(element.attr('ng-minlength')).toEqual('5');
+        });
+
+        it('copies the validation and global config to the input element', function () {
+            scope.config = {
+                globals:{
+                    'aa-valid-icon':''
+                },
+                validations: {
+                    user:{
+                        name: {
+                            'ng-minlength':5
+                        }
+                    }
+                }
+            };
+            scope.user = {
+                name:'test'
+            };
+
+            var directive = angular.element("<aa-configured-form validation-config=\"config\" form-name=\"'exampleForm'\"></aa-configured-form>");
+            var element = angular.element('<input type="test" ng-model="user.name"/>');
+            directive.append(element);
+
+            compile(directive)(scope);
+            element = directive.find('input');
+            expect(element.attr('aa-valid-icon')).toEqual('');
+        });
+
+        it('resolves the validation name using the "resolve" property', function () {
+            scope.config = {
+                resolve: {
+                    user:'UserType'
+                },
+                validations: {
+                    'UserType':{
+                        name: {
+                            'aa-valid-icon':''
+                        }
+                    }
+                }
+            };
+            scope.user = {
+                name:'test'
+            };
+
+            var directive = angular.element("<aa-configured-form validation-config=\"config\" form-name=\"'exampleForm'\"></aa-configured-form>");
+            var element = angular.element('<input type="test" ng-model="user.name"/>');
+            directive.append(element);
+
+            compile(directive)(scope);
+            element = directive.find('input');
+            expect(element.attr('aa-valid-icon')).toEqual('');
+        });
+
+        it('resolves the validation name using the "resolveFn" function', function () {
+            scope.config = {
+                resolveFn: function(modelValue){
+                    return 'UserType';
+                },
+                validations: {
+                    'UserType':{
+                        name: {
+                            'aa-valid-icon':''
+                        }
+                    }
+                }
+            };
+            scope.user = {
+                name:'test'
+            };
+
+            var directive = angular.element("<aa-configured-form validation-config=\"config\" form-name=\"'exampleForm'\"></aa-configured-form>");
+            var element = angular.element('<input type="test" ng-model="user.name"/>');
+            directive.append(element);
+
+            compile(directive)(scope);
+            element = directive.find('input');
+            expect(element.attr('aa-valid-icon')).toEqual('');
+        });
+
+    });
+});


### PR DESCRIPTION
In my current project I have the requirement to be able to pull validation specs from
the server, instead of having them hardcoded in the HTML.
To achieve this I've created what I call the 'aa.formExternalConfiguration' extension.
Its basically one directive that wraps form elements and decorates these with validation attributes according
to a JavaScript object that contains the specifications.

I've added a bunch of example usages in the ngdoc comments, there's also unit tests for the directive.

I thought this might be an interesting addition to AngularAgility, please have a look and tell me what you think.

This is the first commit of my code, so there might still be some bugs lurking here and there.
