### PR TITLE
Add attribute aaConfirmationMessage to manually disable confirmation mes...

### DIFF
--- a/src/aa.formExtensions.js
+++ b/src/aa.formExtensions.js
@@ -1174,7 +1174,8 @@
                         }
 
                         //only root forms get the opportunity to block router state changes
-                        if(!parentForm) {
+                        //add option to disable confirmation messages e.g. after form submit user redirection
+                        if(!parentForm  && attrs.aaConfirmationMessage !== "false") {
                             var strategy = aaFormExtensions.onNavigateAwayStrategies[attrs.onNavigateAwayStrategy || aaFormExtensions.defaultOnNavigateAwayStrategy ];
                             if(angular.isFunction(strategy)) {
                                 strategy(scope, thisForm, $injector);


### PR DESCRIPTION
Add option to manually disable confirmation message when navigating trought $state.go via ui-router. Usefull when user submits form and you need to navigate him to another state regardless of actual form $pristine/$valid state
