### PR TITLE
Fix default navigateAwayStrategy not confirming more than once per route

### DIFF
--- a/src/formExtensions/provider.js
+++ b/src/formExtensions/provider.js
@@ -169,19 +169,16 @@
         //VERY basic. For the love of everything holy please do something better with UI Bootstrap modal or something!
         //requires >= v0.2.10!
         confirmUiRouterAndDom: function (rootFormScope, rootForm, $injector) {
+          var confirmationMessage  = 'You have unsaved changes are you sure you want to navigate away?';
 
           //ANGULAR UI ROUTER
           var onDereg = rootFormScope.$on('$stateChangeStart', function (event, toState, toParams) {
 
             if (rootForm.$aaFormExtensions.$changed) {
-              if (!toState.aaUnsavedPrompted) {
+              if (!window.confirm(confirmationMessage  )) {
+                // stop ui-router's transitioning
+                // Per ui-router documentation, this will cause ui-router to reject the transition promise
                 event.preventDefault();
-                if (window.confirm('You have unsaved changes are you sure you want to navigate away?')) {
-                  //should be able to use options { notify: false } on UI Router
-                  //but that doesn't seem to work right (new state never loads!) so this is a workaround
-                  toState.aaUnsavedPrompted = true;
-                  $injector.get('$state').go(toState.name, toParams);
-                }
               }
             }
           });
@@ -189,7 +186,6 @@
           //NATIVE DOM IE9+
           function beforeUnload(e) {
             if (rootForm.$aaFormExtensions.$changed) {
-              var confirmationMessage = 'You have unsaved changes are you sure you want to navigate away?';
               (e || window.event).returnValue = confirmationMessage;
               return confirmationMessage;
             }
@@ -198,7 +194,6 @@
           window.addEventListener('beforeunload', beforeUnload);
 
           rootFormScope.$on('$destroy', function () {
-            onDereg();
             window.removeEventListener('beforeunload', beforeUnload);
           });
 


### PR DESCRIPTION
fixed issue were confirmUiRouterAndDom onNavigateAwayStrategy would not fire again when navigating to the same route and have dirty fields.

To reproduce issue:
Given page with 2+ routes
and one page with aaForm
1. change a form value
2. navigate to other route
3. note confirmation prompt
4. select on (continue)
5. navigate back to form
6. change form value again
7. navigate to other route (same as 2)
Note: this time there was no confirmation

This change pulls the code into line with ui-routers event documentation: https://github.com/angular-ui/ui-router/wiki#state-change-events
