### PR TITLE
Update aa.formExternalConfiguration.js

### DIFF
--- a/src/formExtensions/aa.formExternalConfiguration.js
+++ b/src/formExtensions/aa.formExternalConfiguration.js
@@ -364,7 +364,7 @@
         },
         processElement: function (jqElm, nameAttr, validationConfig) {
           if (!jqElm.attr('name')) {
-            jqElm.attr('name', nameAttr.split('.').join('-'));
+            jqElm.attr('name', nameAttr.substring(nameAttr.lastIndexOf('.') + 1));
           }
           this.addValidations(jqElm, nameAttr, validationConfig);
         },


### PR DESCRIPTION
Fixed error show in this plnkr http://plnkr.co/edit/WVgDZBx0RudzjjAO5pp1?p=preview
referenced in https://github.com/AngularAgility/AngularAgility/pull/53
There is a difference in how External Form Config and Agility applies the "name" attribute on its inputs. Agility just uses the property name (thus "user.name" is just "name") however ExternalFormConfig uses "user-name". I modified this code to use the same as the Agility code. I'm not sure I understand why both are doing the same job of applying a "name" attribute on the field. But this fixes this issue, their might be a larger one.
