### PR TITLE
aaLabel - render directives within the label strategy

### DIFF
--- a/src/formExtensions/directives/aaLabel.js
+++ b/src/formExtensions/directives/aaLabel.js
@@ -10,7 +10,7 @@
 
   angular.module('aa.formExtensions')
     //generate a label for an input generating an ID for it if it doesn't already exist
-    .directive('aaLabel', ['aaFormExtensions', 'aaUtils', function (aaFormExtensions, aaUtils) {
+    .directive('aaLabel', ['aaFormExtensions', 'aaUtils', '$compile', function (aaFormExtensions, aaUtils, $compile) {
       return {
         compile: function (element, attrs) {
 
@@ -58,7 +58,10 @@
               element[0].id = aaUtils.guid();
             }
 
-            strategy(element, attrs.aaLabel, isRequiredField);
+            var label = strategy(element, attrs.aaLabel, isRequiredField);
+            if (label) {
+                $compile(label)(scope);
+            }
           };
         }
       };


### PR DESCRIPTION
This change will execute $compile on the generated label (within aaLabel) which allows it to support rendering directives within the label (like the angular-ui tooltip for example). 

This change would be backward compatible. Within a custom label strategy, the author would have to return the label element that they generated if they wanted it compiled. If not, no change to the strategy code would be required.
