### PR TITLE
angular version bump and ignoring minor updates for the future

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
         "Procfile"
     ],
     "dependencies": {
-        "angular": "1.2.0"
+        "angular": "~1.2.23"
     }
 }


### PR DESCRIPTION
Change the dependent angular version to '~1.2.23'. Right now bower is prompting us to choose a version because this library specifically requests 1.2.0. I figure any 1.2 version will work (~1.2.23 will grab any 1.2 version, but not 1.3 versions).
