### PR TITLE
Exposed fieldInFormExtensions for template use

### DIFF
--- a/src/formExtensions/directives/aaValMsgFor.js
+++ b/src/formExtensions/directives/aaValMsgFor.js
@@ -26,11 +26,11 @@
           //TODO: if this is inside an isolate scope and the form is outside the isolate scope this doesn't work
           //could nest multiple forms so can't trust directive require and have to eval to handle edge cases...
           aaUtils.ensureaaFormExtensionsFieldExists(formObj, fieldInForm.$name);
-          var fieldInFormExtensions = $scope.$eval(fullFieldPath.replace('.', '.$aaFormExtensions.'));
+          $scope.fieldInFormExtensions = $scope.$eval(fullFieldPath.replace('.', '.$aaFormExtensions.'));
 
           $scope.$watchCollection(
             function () {
-              return fieldInFormExtensions.$errorMessages;
+              return $scope.fieldInFormExtensions.$errorMessages;
             },
             function (val) {
               $scope.errorMessages = val;
@@ -41,7 +41,7 @@
             function () {
               return [
                 formObj.$aaFormExtensions.$invalidAttempt,
-                fieldInFormExtensions.showErrorReasons
+                $scope.fieldInFormExtensions.showErrorReasons
               ];
             },
             function (watches) {


### PR DESCRIPTION
In my scenario I would like to pass some validation parameters to my message template (I can store them in $NgModelController) like this:

``` html
{{msg | translate: fieldInFormExtensions.$ngModel.validationParams}}
```

In my notify config template I can use already provided field object:

``` html
{{ error.message | translate:error.field.$ngModel.validationParams}}
```

validationParams is filled by my custom validators.

It seams that change is pretty safe - just exposing fieldInFormExtensions variable via $scope.
btw. - great library!
