### PR TITLE
enhancement(NoValMsg):Added aa-no-val-msg to block aa-val-msg generation

### DIFF
--- a/src/formExtensions/directives/aaField.js
+++ b/src/formExtensions/directives/aaField.js
@@ -46,7 +46,9 @@
             element.attr('aa-label', aaUtils.toTitleCase(aaUtils.splitCamelCase(lastPartOfName)));
           }
 
-          element.attr("aa-val-msg", "");
+          if (attrs.aanovalmsg === undefined){ 
+            element.attr("aa-val-msg", "");
+          }
 
           element.removeAttr('aa-field');
 

--- a/test/aa.formExtensionsSpecs.js
+++ b/test/aa.formExtensionsSpecs.js
@@ -1,7 +1,7 @@
-describe('aa.formExtensions.js >', function () {
+describe('aa.formExtensions.js >', function() {
     beforeEach(module('aa.formExtensions'));
 
-    describe('aaField >', function () {
+    describe('aaField >', function() {
         var scope, form, element;
 
         beforeEach(inject(function($compile, $rootScope) {
@@ -14,8 +14,17 @@ describe('aa.formExtensions.js >', function () {
             $compile(form)(scope);
         }));
 
-        it('copies field name to ng-model', function () {
+        it('copies field name to ng-model', function() {
             expect(element.attr('ng-model')).toEqual('testEmail');
         });
+        it('appends aa-val-msg attribute', function() {
+            expect(element.attr('aa-val-msg')).toBeDefined();
+        });
+        it('when aa-no-val-msg does not append aa-val-msg attribute', inject(function($compile) {
+            element = angular.element('<input type="email" aa-field="testEmail" aa-no-val-msg>');
+            $compile(form)(scope);
+
+            expect(element.attr('aa-val-msg')).not.toBeDefined();
+        }));
     });
 });


### PR DESCRIPTION
It's usefull when You don't want to generate aa-val-msg, ie. for:

``` html
<p class="form-control-static">value</p>
```
