### PR TITLE
removed addition of form enter event handler when aaSubmitForm element has type='submit'

### DIFF
--- a/src/formExtensions/directives/aaSubmitForm.js
+++ b/src/formExtensions/directives/aaSubmitForm.js
@@ -39,11 +39,6 @@
           }
 
           element.on('click', submit);
-
-          if (attrs.type === 'submit') {
-            //this should be the form's default 'on enter' behavior for submission
-            ngForm.$aaFormExtensions.$onEnterKey = submit;
-          }
         }
       };
     }]);


### PR DESCRIPTION
This is to fix issue: #84 

For my project we have to support IE 8. We don't set the attribute type to submit on our form buttons, however IE 8 is automatically adding them. Thus some of our forms double submit when the enter key is pressed.
