### PR TITLE
handle names with several dots

### DIFF
--- a/src/formExtensions/directives/aaValMsgFor.js
+++ b/src/formExtensions/directives/aaValMsgFor.js
@@ -40,7 +40,7 @@
           //TODO: if this is inside an isolate scope and the form is outside the isolate scope this doesn't work
           //could nest multiple forms so can't trust directive require and have to eval to handle edge cases...
           aaUtils.ensureaaFormExtensionsFieldExists(formObj, fieldInForm.$name);
-          $scope.fieldInFormExtensions = innerScope.$eval(fullFieldPath.replace('.', '.$aaFormExtensions.'));
+          $scope.fieldInFormExtensions = innerScope.$eval(formName + ".$aaFormExtensions" + fieldPath);
 
           $scope.$watchCollection(
             function () {

--- a/src/formExtensions/directives/aaValMsgFor.js
+++ b/src/formExtensions/directives/aaValMsgFor.js
@@ -23,9 +23,14 @@
           var  fieldInForm, formObj; 
 
           var innerScope = $scope;
-          while((!fieldInForm || !formObj) && innerScope){
-            fieldInForm = innerScope.$eval(fullFieldPath);
-            formObj = innerScope.$eval(fullFieldPath.substring(0, fullFieldPath.indexOf('.')));
+          var parts = fullFieldPath.split(".");
+          var formName = parts.shift();
+          var fieldPath = "['" + parts.join(".") + "']"; // filed path without form name, as array accessor
+          var fieldFormPath = formName + fieldPath;
+
+          while ((!fieldInForm || !formObj) && innerScope) {
+            fieldInForm = innerScope.$eval(fieldFormPath);
+            formObj = innerScope.$eval(formName);
             
             if((!fieldInForm || !formObj)){
               innerScope = innerScope.$parent;

--- a/test/aa.valMsgSpecs.js
+++ b/test/aa.valMsgSpecs.js
@@ -1,0 +1,21 @@
+describe('aa.formExtensions.js >', function() {
+    beforeEach(module('aa.formExtensions'));
+
+    describe('aaValMsg >', function() {
+        var scope, form, element;
+
+        beforeEach(inject(function($compile, $rootScope) {
+            scope = $rootScope.$new();
+
+            form = angular.element('<div ng-form="exampleForm"></div>');
+            element = angular.element('<input type="email" ng-model="current.user.email" name="current.user.email" aa-val-msg >');
+            form.append(element);
+
+            $compile(form)(scope);
+        }));
+
+        it('handles many dots', function() {
+	    //just make sure there is no exceptions
+        });
+    });
+});


### PR DESCRIPTION
When we have field with name and ng-model with complex property like this **"current.customer.email"**, **aa-val-msg-for** throws exception, cause it cannot find field. The problem, is that fields are stored as string key, not complex objects if form object (e.g **formName["current.customer.email"]** but not **formName.current.customer.email**)