### PR TITLE
New directive for setting select's default option

### DIFF
--- a/src/formExtensions/directives/aaLabel.js
+++ b/src/formExtensions/directives/aaLabel.js
@@ -13,28 +13,6 @@
     .directive('aaLabel', ['aaFormExtensions', 'aaUtils', '$compile', '$injector', function (aaFormExtensions, aaUtils, $compile, $injector) {
       return {
         compile: function (element, attrs) {
-
-          //add default option if specified
-          //if this is a select with a default-option attribute add a default option (per ng spec)
-          if (element.prop('tagName').toUpperCase() === 'SELECT' && attrs.defaultOption !== undefined) {
-
-            var msg = attrs.defaultOption;
-
-            if (msg === null || msg === "") {
-
-              //gen one
-              msg = 'Select';
-
-              if (attrs.aaLabel) {
-                msg += ' a ' + attrs.aaLabel;
-              }
-
-              msg += '...';
-            }
-
-            element.append(angular.element('<option value=""></option>').html(msg));
-          }
-
           return function (scope, element, attrs) {
             var strategy = aaFormExtensions.labelStrategies[attrs.aaLabelStrategy];
 

--- a/src/formExtensions/directives/defaultOption.js
+++ b/src/formExtensions/directives/defaultOption.js
@@ -1,0 +1,46 @@
+/**
+ * @ngdoc directive
+ * @name defaultOption
+ *
+ * @description
+ * Directive allowing to place a default option on select elements.
+ **/
+(function () {
+  'use strict';
+
+  angular.module('aa.formExtensions')
+    //generate a label for an input generating an ID for it if it doesn't already exist
+    .directive('defaultOption', ['aaFormExtensions', 'aaUtils', '$compile', '$injector', function (aaFormExtensions, aaUtils, $compile, $injector) {
+      return {
+          priority: -1000,
+        link: function (scope, element, attrs) {
+          //add default option if specified
+          //if this is a select with a default-option attribute add a default option (per ng spec)
+          if (element.prop('tagName').toUpperCase() === 'SELECT' && attrs.defaultOption !== undefined) {
+
+            var msg = attrs.defaultOption;
+
+            if (msg === null || msg === "") {
+
+              //gen one
+              msg = 'Select';
+
+              if (attrs.aaLabel) {
+                msg += ' a ' + attrs.aaLabel;
+              }
+
+              msg += '...';
+            }
+              
+              var options = element.children('option[value=""]');
+              
+              if(!options.length) {
+                element.append(angular.element('<option value=""></option>').html(msg));
+              
+              element.removeAttr('default-option');
+              }
+          }
+        }
+      };
+    }]);
+})();


### PR DESCRIPTION
I moved the defaultOption attribute from aaLabel directive to a separate
directive, because when select element had an attribute of "no-label",
the aaLabel directive was not created at all, and therefore
defaultOption was not set as well.