### PR TITLE
allow customization or translation of 'this field'

### DIFF
--- a/src/formExtensions/directives/ngModel.js
+++ b/src/formExtensions/directives/ngModel.js
@@ -20,7 +20,7 @@
           link: function (scope, element, attrs, controllers) {
             var ngModel = controllers[0],
               ngForm = controllers[1],
-              fieldName = "This field";
+              fieldName = aaFormExtensions.defaultFieldName;
 
             if (!ngForm || !ngModel.$name) {
               //only for validation with forms

--- a/src/formExtensions/provider.js
+++ b/src/formExtensions/provider.js
@@ -215,6 +215,9 @@
       };
 
 
+      this.defaultFieldName = "This field";
+
+
       //VALIDATION MESSAGES
       this.validationMessages = {
         required: "{0} is required.",
@@ -293,6 +296,8 @@
 
           validIconStrategy: self.validIconStrategy,
           validationMessages: self.validationMessages,
+
+          defaultFieldName: self.defaultFieldName,
 
           valMsgForTemplate: self.valMsgForTemplate,
 


### PR DESCRIPTION
Currently it is impossible translate string "this field" that is used in messages, when there is no aa-field-name directive is not applied to field. This allows customization or translation of string 'this field'.