### PR TITLE
Fixing defaultOption directive for ngOptions

### DIFF
--- a/src/formExtensions/directives/defaultOption.js
+++ b/src/formExtensions/directives/defaultOption.js
@@ -12,35 +12,40 @@
     //generate a label for an input generating an ID for it if it doesn't already exist
     .directive('defaultOption', ['aaFormExtensions', 'aaUtils', '$compile', '$injector', function (aaFormExtensions, aaUtils, $compile, $injector) {
       return {
-          priority: -1000,
-        link: function (scope, element, attrs) {
-          //add default option if specified
-          //if this is a select with a default-option attribute add a default option (per ng spec)
-          if (element.prop('tagName').toUpperCase() === 'SELECT' && attrs.defaultOption !== undefined) {
+          priority: 1,
+          compile: function (element, attrs) {
+            return {
+                pre: function (scope, element, attrs) {
+                    //add default option if specified
+                  //if this is a select with a default-option attribute add a default option (per ng spec)
+                  if (element.prop('tagName').toUpperCase() === 'SELECT' && attrs.defaultOption !== undefined) {
 
-            var msg = attrs.defaultOption;
+                    var msg = attrs.defaultOption;
 
-            if (msg === null || msg === "") {
+                    if (msg === null || msg === "") {
 
-              //gen one
-              msg = 'Select';
+                      //gen one
+                      msg = 'Select';
 
-              if (attrs.aaLabel) {
-                msg += ' a ' + attrs.aaLabel;
-              }
+                      if (attrs.aaLabel) {
+                        msg += ' a ' + attrs.aaLabel;
+                      }
 
-              msg += '...';
-            }
-              
-              var options = element.children('option[value=""]');
-              
-              if(!options.length) {
-                element.append(angular.element('<option value=""></option>').html(msg));
-              
-              element.removeAttr('default-option');
-              }
+                      msg += '...';
+                    }
+
+                      var options = element.children('option[value=""]');
+
+                      if(!options.length) {
+                        element.append(angular.element('<option value=""></option>').html(msg));
+
+                      element.removeAttr('default-option');
+                      }
+                  }
+                }
+            };
           }
-        }
+          
       };
     }]);
 })();


### PR DESCRIPTION
defaultOption did not work correctly with ng-options directive, because
it had priority set to a negative value. ngOptions directive has a
'terminal' property defined in its directive definition object, and
because of that defaultOption directive was never linked. Current case
works well with cases when ngOptions is used, as well as with cases when
user defines the options using HTML tags.