### PR TITLE
Adds clearing errors on ngForm.$setPristine() invocation and possible memory leak.

### DIFF
--- a/src/formExtensions/directives/ngForm.js
+++ b/src/formExtensions/directives/ngForm.js
@@ -56,7 +56,7 @@
               };
             }
 
-			var currentSetPristine = thisForm.$setPristine;
+            var currentSetPristine = thisForm.$setPristine;
             thisForm.$setPristine = function () {
                 $clearErrors(currentSetPristine.bind(thisForm));
             };
@@ -310,12 +310,12 @@
                     err.field.$element.removeClass('aa-had-focus');
                     //this makes sense i think, maybe make configurable
                     // Explanation:
-                    //It would be better if $clearErrors function clears only aa.formExtensions's state.
-                    //aa.formExtensions for ngForm, so it should also extend ngForm.$setPristine() to clear its state.
+                    //It would be better if $clearErrors() function clears only aa.formExtensions's state.
+                    //aa.form is extension for ngForm, so it should extend ngForm.$setPristine() to clear its state.
                     //HOW it looks from consumers's side: when developer calls hisForm.$setPristine(),
-                    //he expects that all ngForm's extensions must clear their errors as well
-                    //and should not call (and even know) about method hisForm.$aaFormExtensions.$clearErrors.
-                    //Especially because $clearErrors method is not well documented.
+                    //he expects that all ngForm's extensions must clear their errors as well.
+                    //And he should not call (and even know) method hisForm.$aaFormExtensions.$clearErrors().
+                    //Especially because $clearErrors() method is not well documented.
                     //err.field.$ngModel.$setPristine();
                   }
                 });

--- a/src/formExtensions/directives/ngForm.js
+++ b/src/formExtensions/directives/ngForm.js
@@ -56,6 +56,10 @@
               };
             }
 
+			var currentSetPristine = thisForm.$setPristine;
+            thisForm.$setPristine = function () {
+                $clearErrors(currentSetPristine.bind(thisForm));
+            };
 
             thisForm.$aaFormExtensions = {
               $onSubmitAttempt: function () {
@@ -305,7 +309,14 @@
                     err.field.showErrorReasons.length = 0;
                     err.field.$element.removeClass('aa-had-focus');
                     //this makes sense i think, maybe make configurable
-                    err.field.$ngModel.$setPristine();
+                    // Explanation:
+                    //It would be better if $clearErrors function clears only aa.formExtensions's state.
+                    //aa.formExtensions for ngForm, so it should also extend ngForm.$setPristine() to clear its state.
+                    //HOW it looks from consumers's side: when developer calls hisForm.$setPristine(),
+                    //he expects that all ngForm's extensions must clear their errors as well
+                    //and should not call (and even know) about method hisForm.$aaFormExtensions.$clearErrors.
+                    //Especially because $clearErrors method is not well documented.
+                    //err.field.$ngModel.$setPristine();
                   }
                 });
 

--- a/src/formExtensions/directives/ngModel.js
+++ b/src/formExtensions/directives/ngModel.js
@@ -50,8 +50,12 @@
             }
 
 
-            element.on('blur', function () {
-              field.showErrorReasons.push('hadFocus');
+            element.on('blur', function () {			
+              var blurReason = 'hadFocus';
+
+              if (field.showErrorReasons.indexOf(blurReason) === -1) {
+                  field.showErrorReasons.push(blurReason);
+              }
               element.addClass('aa-had-focus');
 
               //want to call $apply after current stack clears


### PR DESCRIPTION
1) ngForm.js:
It is more convenient for consumers to clear all form's validation errors on ngForm.$setPristine() instead of additional call to ngForm.$aaFormExtensions.$clearErrors().

2) ngModel.js:
It seems there was a little memory leak in element's 'blur' event listener (the 'showErrorReasons' array is increased on every event).