### PR TITLE
Add aaIsLoadingIgnoreTemplate flag to aaFormExtensions

### DIFF
--- a/src/formExtensions/module.js
+++ b/src/formExtensions/module.js
@@ -82,7 +82,11 @@
         function (aaLoadingWatcher, $q, aaFormExtensions) {
 
           function shouldIgnore(config) {
-            return config.aaIsLoadingIgnore === true || config.cached;
+            return config.aaIsLoadingIgnore === true || 
+              config.cached ||
+              (aaFormExtensions.aaIsLoadingIgnoreTemplate && 
+                config.url &&
+                config.url.indexOf('.html') > -1);
           }
 
           return {

--- a/src/formExtensions/provider.js
+++ b/src/formExtensions/provider.js
@@ -293,6 +293,7 @@
       };
 
       this.aaIsLoadingDoneDebounceMS = 500; //wait Xms before considered done loading to avoid avoid flickering
+      this.aaIsLoadingIgnoreTemplate = false; //should a template load trigger an aa loading
 
       this.$get = function () {
         return {
@@ -331,7 +332,9 @@
           //todo wire up
           globalSettings: self.globalSettings,
 
-          aaIsLoadingDoneDebounceMS: self.aaIsLoadingDoneDebounceMS
+          aaIsLoadingDoneDebounceMS: self.aaIsLoadingDoneDebounceMS,
+          aaIsLoadingIgnoreTemplate: self.aaIsLoadingIgnoreTemplate
+
         };
       };
     });


### PR DESCRIPTION
This allows a user to instruct `aaAjaxInterceptor` to not increment the aaLoadingWatcher count if the request it intercepted is an `.html` file load. That could be parameterized further (e.g. list of patterns to ignore instead of a hardcoded flag + .html) if necessary.

This PR does not change existing behavior as the `aaFormExtensions.aaIsLoadingIgnoreTemplate` flag defaults to `false`.

This behavior could also be implemented in an application's custom `httpInterceptor` with the `aaIsLoadingIgnore` flag, but only if that interceptor is guaranteed to be executed before `aaAjaxInterceptor` -- a condition that not all users of this lib may be able to reason about.