### PR TITLE
Add Css class to field group

### DIFF
--- a/src/formExtensions/aa.formExternalConfiguration.js
+++ b/src/formExtensions/aa.formExternalConfiguration.js
@@ -352,7 +352,7 @@
           var _this = this;
           angular.forEach(elements, function (element) {
             var jqElm = angular.element(element);
-            var modelAttr = jqElm.attr('aa-config-model') ||  jqElm.attr('ng-model') || jqElm.attr('data-ng-model') || jqElm.attr('ngModel') || jqElm.attr('aa-field') || jqElm.attr('aa-field-group') || jqElm.attr('data-aa-field') || jqElm.attr('data-aa-field-group');
+            var modelAttr = jqElm.attr('ng-model') || jqElm.attr('data-ng-model') || jqElm.attr('ngModel') || jqElm.attr('aa-field') || jqElm.attr('aa-field-group') || jqElm.attr('data-aa-field') || jqElm.attr('data-aa-field-group');
             if (modelAttr) {
               if (validationConfig.ignore[jqElm[0].name]) {
                 return;

--- a/src/formExtensions/provider.js
+++ b/src/formExtensions/provider.js
@@ -81,7 +81,7 @@
 
           var col = findClosestEleWithAttr(element, 'aa-col') || self.defaultCol;
 
-          wrap(element, '<div class="form-group"><div class="col-' + col + '"></div></div>');
+          wrap(element, '<div class="form-group aaFieldGroup"><div class="col-' + col + '"></div></div>');
         },
         bootstrap3BasicFormWithSize: function (element, $injector) {
 
@@ -92,7 +92,7 @@
 
           var col = findClosestEleWithAttr(element, 'aa-col') || self.defaultCol;
 
-          wrap(element, '<div class="form-group col-' + col + '"></div>');
+          wrap(element, '<div class="form-group aaFieldGroup col-' + col + '"></div>');
         }
       };
 


### PR DESCRIPTION
Add the css class 'aaFieldGroup' when the field group strategy is used. 
It is important for some components, e.g. ui-select, that uses css