### PR TITLE
fix(formExtensions): unique error messages

### DIFF
--- a/src/formExtensions/directives/ngModel.js
+++ b/src/formExtensions/directives/ngModel.js
@@ -172,6 +172,7 @@
 
             function calcErrorMessages() {
               var fieldErrorMessages = field.$errorMessages,
+                newFieldErrorMessages = {},
                 msg;
 
               //clear out the validation messages that exist on *just the field*
@@ -210,8 +211,12 @@
                     msg = aaUtils.stringFormat(aaFormExtensions.validationMessages.unknown, fieldName);
                   }
 
-                  fieldErrorMessages.push(msg);
+                  newFieldErrorMessages[msg] = true;
                 }
+              }
+
+              for (var k in newFieldErrorMessages) {
+                fieldErrorMessages.push(k);
               }
 
               clearAndUpdateValidationMessages(ngForm, fieldErrorMessages);


### PR DESCRIPTION
This should fix a bug when there are multiple unrecognized keys in the `ngModel.$error` object, causing redundant error messages to appear to the user as well as causing the `ng-repeat` in the [template](https://github.com/AngularAgility/AngularAgility/blob/eeb3fae28be9b95bd79398e984171b068e615def/src/aa.formExtensions.js#L125) for aaNotify to log a bunch of [dupes errors](https://docs.angularjs.org/error/ngRepeat/dupes).

