### PR TITLE
chore(pkg): update karma, grunt-karma, & karma-phantomjs-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
     "angular": ">=1.2.0"
   },
   "devDependencies": {
-    "express": "^3.10.2",
-    "lodash": "^2.4.1",
     "body-parser": "^1.3.0",
     "bower": "*",
+    "express": "^3.10.2",
     "grunt": "*",
     "grunt-bump": "0.0.14",
     "grunt-contrib-concat": "^0.3.0",
@@ -17,16 +16,17 @@
     "grunt-contrib-uglify": "^0.2.2",
     "grunt-contrib-watch": "^0.5.3",
     "grunt-istanbul-coverage": "^0.0.5",
-    "grunt-karma": "^0.6.2",
+    "grunt-karma": "^2.0.0",
     "grunt-ngdocs": "*",
-    "karma": "^0.10.9",
+    "karma": "^1.4.0",
     "karma-chrome-launcher": "^0.1.2",
     "karma-coverage": "^0.2.1",
     "karma-firefox-launcher": "^0.1.3",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jasmine": "^0.1.5",
-    "karma-phantomjs-launcher": "^0.1.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-script-launcher": "^0.1.0",
+    "lodash": "^2.4.1",
     "matchdep": "^0.3.0"
   },
   "repository": {


### PR DESCRIPTION
Updates karma, grunt-karma, & karma-phantomjs-launcher. The `npm test` command wasn't working otherwise for me on Node 7.4.0 with npm 4.0.5 on macOS 10.12.2 (16C67).