### PR TITLE
fixed the issue with clearError after update angular 1.6.1

### DIFF
--- a/src/formExtensions/directives/ngForm.js
+++ b/src/formExtensions/directives/ngForm.js
@@ -262,7 +262,9 @@
                     dep.field.$ngModel.$render();
                     dep.field.showErrorReasons.length = 0;
                     dep.field.$ngModel.$setPristine();
-                    (dep.field.$ngModel.$setUntouched || angular.noop)();
+                    if(dep.field.$ngModel.$setUntouched) {
+                      dep.field.$ngModel.$setUntouched();
+                    }
                   }
 
                   if (dep.expr) {
@@ -319,14 +321,18 @@
 
               setAttemptRecursively(thisForm, false);
               thisForm.$setPristine();
-              (thisForm.$setUntouched || angular.noop)();
+              if(thisForm.$setUntouched) {
+                thisForm.$setUntouched();
+              }
 
               angular.forEach(thisForm.$aaFormExtensions.$allValidationErrors, function (err) {
                 if (err.field) {
                   err.field.showErrorReasons.length = 0;
                   err.field.$element.removeClass('aa-had-focus');
                   err.field.$ngModel.$setPristine();
-                  (err.field.$ngModel.$setUntouched || angular.noop)();
+                  if(err.field.$ngModel.$setUntouched) {
+                    err.field.$ngModel.$setUntouched();
+                  }
                 }
               });
 


### PR DESCRIPTION
After Update Angular 1.6.1 i get this issue when I call form.$clearErrors 

TypeError: Cannot read property '$$controls' of undefined
    at $setUntouched (angular.js:22874)
    at Object.$clearErrors (angular-agility.js:2598)
    at fn (eval at compile (angular.js:15156), <anonymous>:4:229)
    at callback (angular.js:26744)
    at Scope.$eval (angular.js:17972)
    at Scope.$apply (angular.js:18072)
    at HTMLButtonElement.<anonymous> (angular.js:26749)
    at HTMLButtonElement.dispatch (jquery.js:4737)
    at HTMLButtonElement.elemData.handle (jquery.js:4549)


So i fixed that please check and accept my merge Request