### PR TITLE
Solves unhandled rejections with Angular >= 1.5.9

### DIFF
--- a/src/formExtensions/directives/aaSubmitForm.js
+++ b/src/formExtensions/directives/aaSubmitForm.js
@@ -30,7 +30,11 @@
               //if this isn't a promise it will resolve immediately
               $q.when(scope.aaSubmitForm()).then(function(){
                 ngForm.$setSubmitted();
-              })["finally"](function (result) {
+              })
+              .catch(function(result){
+                  // If the promise is rejected, just catch the error to solve the unhandled rejection error in angular >=1.59
+              })
+              .finally(function (result) {
                 eleSpinnerClickStrategy.after();
                 return result;
               });


### PR DESCRIPTION
Angular >=1.5.9 throws an Unhandled rejection when the promise doesn't have a catch function. I added just the catch function with a comment to solve this error.